### PR TITLE
added mailing lists and subgroups to README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This task force is intended to deliver a reference architecture for what the Ope
   * [Decentralized Identifiers](./docs/architecture/decentralized-identifiers.md)
   * [Key Management Services](./docs/architecture/key-management-services.md)
   * [Verifiable Credentials](./docs/architecture/verifiable-credentials.md)
+* [Mailing List](https://lists.openwallet.foundation/)
+  * [Main Subgroup](https://lists.openwallet.foundation/g/main)
+  * [Technical Subgroup](https://lists.openwallet.foundation/g/technical-discuss)
 * [Meeting Details](./meeting-details.md)
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
added mailing lists to README. As a newcomer, I was looking for additional information, but the links via google don't point to any of the mailing lists, so I wasn't sure where the right place to go was. This seems helpful, so proposing this here, but I could see it migrating to a CONTRIBUTING.md file or something later. 