### PR TITLE
improved specificity on did resolution diagrams

### DIFF
--- a/docs/architecture/decentralized-identifiers.md
+++ b/docs/architecture/decentralized-identifiers.md
@@ -28,9 +28,42 @@ class DIDDocument {
     + List~VerificationMethod~ keyAgreement
     + List~Service~ service
     + create()
-    + resolve()
+    + resolve() : DIDResolutionResult
     + update()
     + deactivate()
+}
+
+class DIDResolutionResult {
+    <<Abstract>>
+    + DIDResolutionMetadata ResolutionMetadata
+    + DIDDocument DIDDocument
+    + DIDDocumentMetadata DIDDocumentMetadata
+}
+
+class DIDDocumentMetadata {
+   <<Abstract>>
+   + String Created
+   + String Updated
+   + bool Deactivated
+   + String NextUpdate
+   + String VersionID
+   + String NextVersionID
+   + String EquivalentID _
+   + String CanonicalID
+}
+
+class ResolutionError {
+    <<Abstract>>
+    + String Code
+    + bool InvalidDID
+    + bool NotFound
+    + bool RepresentationNotSupported
+}
+
+class DIDResolutionMetadata {
+    <<Abstract>>
+    + String ContentType
+    + ResolutionError Error
 }
 
 class VerificationMethod {
@@ -99,7 +132,13 @@ VerificationMethod "1" .. "1" DIDUrl
 VerificationMethod "1" .. "1" DID
 DIDDocument "1" *.. "many" Service
 Service "1" .. "1" DIDUrl
- 
+
+
+DIDResolutionResult "1" .. "many" DIDDocument
+DIDDocumentMetadata "1" .. "1" DIDResolutionResult
+DIDResolutionMetadata "1" .. "1" DIDResolutionResult
+ResolutionError "1" .. "1" DIDResolutionResult
+
 ```
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/architecture/decentralized-identifiers.md
+++ b/docs/architecture/decentralized-identifiers.md
@@ -143,7 +143,7 @@ DIDResolutionResult "1" .. "many" DIDDocument
 DIDDocumentMetadata "1" .. "1" DIDResolutionResult
 DIDResolutionMetadata "1" .. "1" DIDResolutionResult
 ResolutionError "1" .. "1" DIDResolutionResult
-
+ResolutionOptions "many" .. "1" DIDDocument
 ```
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/architecture/decentralized-identifiers.md
+++ b/docs/architecture/decentralized-identifiers.md
@@ -18,6 +18,11 @@ class DIDUrl {
     dereference()
 }
 
+class ResolutionOptions {
+    <<Abstract>>
+    + String Accept
+}
+
 class DIDDocument {
     <<Abstract>>
     + DID id
@@ -28,7 +33,7 @@ class DIDDocument {
     + List~VerificationMethod~ keyAgreement
     + List~Service~ service
     + create()
-    + resolve() : DIDResolutionResult
+    + resolve(ResolutionOptions options) : DIDResolutionResult
     + update()
     + deactivate()
 }

--- a/docs/architecture/decentralized-identifiers.md
+++ b/docs/architecture/decentralized-identifiers.md
@@ -139,7 +139,7 @@ DIDDocument "1" *.. "many" Service
 Service "1" .. "1" DIDUrl
 
 
-DIDResolutionResult "1" .. "many" DIDDocument
+DIDResolutionResult "many" .. "1" DIDDocument
 DIDDocumentMetadata "1" .. "1" DIDResolutionResult
 DIDResolutionMetadata "1" .. "1" DIDResolutionResult
 ResolutionError "1" .. "1" DIDResolutionResult


### PR DESCRIPTION
According to https://www.w3.org/TR/did-core/#did-resolution, did resolution follows the following interface: 

```
resolve(did, resolutionOptions) →
   « didResolutionMetadata, didDocument, didDocumentMetadata »
```

I've added the objects didResolutionMetadata, didDocumentMetadata to the diagrams with the appropriate interfaces. 

Thank you for the review!